### PR TITLE
Srk tweaks

### DIFF
--- a/diffrax/__init__.py
+++ b/diffrax/__init__.py
@@ -18,7 +18,6 @@ from ._custom_types import (
     AbstractSpaceTimeLevyArea as AbstractSpaceTimeLevyArea,
     AbstractSpaceTimeTimeLevyArea as AbstractSpaceTimeTimeLevyArea,
     BrownianIncrement as BrownianIncrement,
-    resulting_levy_area as resulting_levy_area,
     SpaceTimeLevyArea as SpaceTimeLevyArea,
     SpaceTimeTimeLevyArea as SpaceTimeTimeLevyArea,
 )

--- a/diffrax/_custom_types.py
+++ b/diffrax/_custom_types.py
@@ -84,37 +84,6 @@ class SpaceTimeTimeLevyArea(AbstractSpaceTimeTimeLevyArea):
     K: PyTree[Array]
 
 
-def resulting_levy_area(
-    levy_area1: type[AbstractBrownianIncrement],
-    levy_area2: type[AbstractBrownianIncrement],
-) -> type[AbstractBrownianIncrement]:
-    """A helper that returns the stricter Levy area.
-
-    **Arguments:**
-
-    - `levy_area1`: The first Levy area type.
-    - `levy_area2`: The second Levy area type.
-
-    **Returns:**
-
-    `BrownianIncrement`, `SpaceTimeLevyArea`, or `SpaceTimeTimeLevyArea`.
-    """
-    if issubclass(levy_area1, AbstractSpaceTimeTimeLevyArea) or issubclass(
-        levy_area2, AbstractSpaceTimeTimeLevyArea
-    ):
-        return SpaceTimeTimeLevyArea
-    elif issubclass(levy_area1, AbstractSpaceTimeLevyArea) or issubclass(
-        levy_area2, AbstractSpaceTimeLevyArea
-    ):
-        return SpaceTimeLevyArea
-    elif issubclass(levy_area1, AbstractBrownianIncrement) or issubclass(
-        levy_area2, AbstractBrownianIncrement
-    ):
-        return BrownianIncrement
-    else:
-        raise ValueError("Invalid levy area types.")
-
-
 def levy_tree_transpose(
     tree_shape, tree: PyTree[AbstractBrownianIncrement]
 ) -> AbstractBrownianIncrement:

--- a/diffrax/_solver/sea.py
+++ b/diffrax/_solver/sea.py
@@ -3,35 +3,29 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    AdditiveCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, AdditiveCoeffs, StochasticButcherTableau
 
 
-cfs_w = AdditiveCoeffs(
+_coeffs_w = AdditiveCoeffs(
     a=np.array([0.5]),
-    b=np.array(1.0),
+    b_sol=np.array(1.0),
 )
 
-cfs_hh = AdditiveCoeffs(
+_coeffs_hh = AdditiveCoeffs(
     a=np.array([1.0]),
-    b=np.array(0.0),
-)
-
-cfs_bm = SpaceTimeLevyAreaTableau[AdditiveCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
+    b_sol=np.array(0.0),
 )
 
 _tab = StochasticButcherTableau(
-    c=np.array([]),
+    a=[],
     b_sol=np.array([1.0]),
     b_error=None,
-    a=[],
-    cfs_bm=cfs_bm,
+    c=np.array([]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
+    ignore_stage_f=None,
+    ignore_stage_g=None,
 )
 
 

--- a/diffrax/_solver/sea.py
+++ b/diffrax/_solver/sea.py
@@ -37,23 +37,26 @@ _tab = StochasticButcherTableau(
 
 class SEA(AbstractSRK, AbstractStratonovichSolver):
     r"""Shifted Euler method for SDEs with additive noise.
-     It has a local error of $O(h^2)$ compared to standard Euler-Maruyama,
-     which has $O(h^{1.5})$. They still have the same global order of $O(h)$
-     for additive noise SDEs, but SEA is better by a constant factor.
 
-    Based on equation $(5.8)$ in
+    Makes one evaluation of the drift and diffusion per step and has a strong order 1.
+    Compared to [`diffrax.Euler`][], it has a better constant factor in the global
+    error, and an improved local error of $O(h^2)$ instead of $O(h^{1.5})$.
+
+    This solver is useful for solving additive-noise SDEs with as few drift and
+    diffusion evaluations per step as possible.
 
     ??? cite "Reference"
 
+        This solver is based on equation (5.8) in
+
         ```bibtex
-        @misc{foster2023high,
-          title={High order splitting methods for SDEs satisfying
-            a commutativity condition},
-          author={James Foster and Goncalo dos Reis and Calum Strange},
-          year={2023},
-          eprint={2210.17543},
-          archivePrefix={arXiv},
-          primaryClass={math.NA}
+        @article{foster2023high,
+            title={High order splitting methods for SDEs satisfying a commutativity
+                   condition},
+            author={James Foster and Goncalo dos Reis and Calum Strange},
+            year={2023},
+            journal={arXiv:2210.17543},
+        }
         ```
     """
 

--- a/diffrax/_solver/shark.py
+++ b/diffrax/_solver/shark.py
@@ -36,24 +36,27 @@ _tab = StochasticButcherTableau(
 
 
 class ShARK(AbstractSRK, AbstractStratonovichSolver):
-    r"""Shifted Additive-noise Runge-Kutta method for SDEs by James Foster.
-    This is the recommended choice for SDEs with additive noise, and can only
-    be used for such SDEs.
-    Uses two evaluations of the vector field per step and has strong order 1.5.
+    r"""Shifted Additive-noise Runge-Kutta method for additive SDEs.
 
-    Based on equation $(6.1)$ in
+    Makes two evaluations of the drift and diffusion per step and has a strong order
+    1.5.
+
+    This is the recommended choice for SDEs with additive noise.
+
+    See also [`diffrax.SRA1`][], which is very similar.
 
     ??? cite "Reference"
 
+        This solver is based on equation (6.1) in
+
         ```bibtex
-        @misc{foster2023high,
-          title={High order splitting methods for SDEs satisfying
-            a commutativity condition},
-          author={James Foster and Goncalo dos Reis and Calum Strange},
-          year={2023},
-          eprint={2210.17543},
-          archivePrefix={arXiv},
-          primaryClass={math.NA}
+        @article{foster2023high,
+            title={High order splitting methods for SDEs satisfying a commutativity
+                   condition},
+            author={James Foster and Goncalo dos Reis and Calum Strange},
+            year={2023},
+            journal={arXiv:2210.17543},
+        }
         ```
     """
 

--- a/diffrax/_solver/shark.py
+++ b/diffrax/_solver/shark.py
@@ -3,35 +3,29 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    AdditiveCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, AdditiveCoeffs, StochasticButcherTableau
 
 
-cfs_w = AdditiveCoeffs(
+_coeffs_w = AdditiveCoeffs(
     a=np.array([0.0, 5 / 6]),
-    b=np.array(1.0),
+    b_sol=np.array(1.0),
 )
 
-cfs_hh = AdditiveCoeffs(
+_coeffs_hh = AdditiveCoeffs(
     a=np.array([1.0, 1.0]),
-    b=np.array(0.0),
-)
-
-cfs_bm = SpaceTimeLevyAreaTableau[AdditiveCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
+    b_sol=np.array(0.0),
 )
 
 _tab = StochasticButcherTableau(
-    c=np.array([5 / 6]),
+    a=[np.array([5 / 6])],
     b_sol=np.array([0.4, 0.6]),
     b_error=np.array([-0.6, 0.6]),
-    a=[np.array([5 / 6])],
-    cfs_bm=cfs_bm,
+    c=np.array([5 / 6]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
+    ignore_stage_f=None,
+    ignore_stage_g=None,
 )
 
 

--- a/diffrax/_solver/shark_general.py
+++ b/diffrax/_solver/shark_general.py
@@ -37,18 +37,19 @@ _tab = StochasticButcherTableau(
 
 
 class GeneralShARK(AbstractSRK, AbstractStratonovichSolver):
-    r"""A generalised version of the ShARK method which now works for
-    any SDE, not only those with additive noise.
-    Applied to SDEs with additive noise, it still has strong order 1.5.
-    Uses two evaluations of the drift vector field and three evaluations
-    of the diffusion vector field per step. For general SDEs, the strong
-    error is similar to that of three steps of Heun's method.
-    This is the recommended solver for general SDEs unless the noise vector filed is
-    commutative in the Lie bracket, in which case SlowRK is recommended.
+    r"""ShARK method for Stratonovich SDEs.
 
-    Based on equation $(6.1)$ from
+    As compared to [`diffrax.ShARK`][] this can handle any SDE, not only those with
+    additive noise.
+
+    Makes two evaluations of the drift and three evaluations of the diffusion per step.
+    For additive SDEs this has strong order 1.5. For general SDEs this has strong order
+    0.5, but with a good coefficient in front (similar to making three steps of
+    [`diffrax.Heun`][]).
 
     ??? cite "Reference"
+
+        This solver is based on equation (6.1) from
 
         ```bibtex
         @misc{foster2023high,

--- a/diffrax/_solver/shark_general.py
+++ b/diffrax/_solver/shark_general.py
@@ -3,38 +3,31 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    GeneralCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, GeneralCoeffs, StochasticButcherTableau
 
 
-cfs_w = GeneralCoeffs(
+_coeffs_w = GeneralCoeffs(
     a=(np.array([0.0]), np.array([0.0, 5 / 6])),
-    b=np.array([0.0, 0.4, 0.6]),
+    b_sol=np.array([0.0, 0.4, 0.6]),
     b_error=None,
 )
 
-cfs_hh = GeneralCoeffs(
+_coeffs_hh = GeneralCoeffs(
     a=(np.array([1.0]), np.array([1.0, 0.0])),
-    b=np.array([0.0, 1.2, -1.2]),
+    b_sol=np.array([0.0, 1.2, -1.2]),
     b_error=None,
-)
-
-cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
 )
 
 _tab = StochasticButcherTableau(
-    c=np.array([0.0, 5 / 6]),
+    a=[np.array([0.0]), np.array([0.0, 5 / 6])],
     b_sol=np.array([0.0, 0.4, 0.6]),
     b_error=None,
-    a=[np.array([0.0]), np.array([0.0, 5 / 6])],
-    cfs_bm=cfs_bm,
+    c=np.array([0.0, 5 / 6]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
     ignore_stage_f=np.array([True, False, False]),
+    ignore_stage_g=None,
 )
 
 

--- a/diffrax/_solver/shark_general.py
+++ b/diffrax/_solver/shark_general.py
@@ -14,11 +14,13 @@ from .srk import (
 cfs_w = GeneralCoeffs(
     a=(np.array([0.0]), np.array([0.0, 5 / 6])),
     b=np.array([0.0, 0.4, 0.6]),
+    b_error=None,
 )
 
 cfs_hh = GeneralCoeffs(
     a=(np.array([1.0]), np.array([1.0, 0.0])),
     b=np.array([0.0, 1.2, -1.2]),
+    b_error=None,
 )
 
 cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](

--- a/diffrax/_solver/slowrk.py
+++ b/diffrax/_solver/slowrk.py
@@ -25,6 +25,7 @@ cfs_w = GeneralCoeffs(
         np.array([0.0, 0.0, 0.5, 0.0, 0.0, 0.0]),
     ),
     b=np.array([0.0, 1 / 6, 1 / 3, 1 / 3, 1 / 6, 0.0, 0.0]),
+    b_error=None,
 )
 
 cfs_hh = GeneralCoeffs(
@@ -37,6 +38,7 @@ cfs_hh = GeneralCoeffs(
         np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     ),
     b=np.array([0.0, 0.0, 0.0, 2.0, 0.0, 0.0, -2.0]),
+    b_error=None,
 )
 
 cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](

--- a/diffrax/_solver/slowrk.py
+++ b/diffrax/_solver/slowrk.py
@@ -11,6 +11,10 @@ from .srk import (
 )
 
 
+# TODO: maybe this solver should use a custom implementation, not going via
+# `AbstractSRK`? Its tableaus have huge amounts of sparsity due to its odd structure.
+
+
 cfs_w = GeneralCoeffs(
     a=(
         np.array([0.0]),
@@ -59,26 +63,28 @@ _tab = StochasticButcherTableau(
 
 
 class SlowRK(AbstractSRK, AbstractStratonovichSolver):
-    r"""SLOW-RK method for SDEs by James Foster.
+    r"""SLOW-RK method for commutative-noise Stratonovich SDEs.
+
+    Makes two evaluations of the drift and five evaluations of the diffusion per step.
     Applied to SDEs with commutative noise, it converges strongly with order 1.5.
     Can be used for SDEs with non-commutative noise, but then it only converges
     strongly with order 0.5.
 
-     Based on equation $(6.2)$ from
+    This solver is an excellent choice for Stratonovich SDEs with commutative noise.
 
     ??? cite "Reference"
 
-        ```bibtex
-        @misc{foster2023high,
-          title={High order splitting methods for SDEs satisfying
-            a commutativity condition},
-          author={James Foster and Goncalo dos Reis and Calum Strange},
-          year={2023},
-          eprint={2210.17543},
-          archivePrefix={arXiv},
-          primaryClass={math.NA}
-        ```
+        This solver is based on equation (6.2) from
 
+        ```bibtex
+        @article{foster2023high,
+            title={High order splitting methods for SDEs satisfying a commutativity
+                   condition},
+            author={James Foster and Goncalo dos Reis and Calum Strange},
+            year={2023},
+            journal={arXiv:2210.17543},
+        }
+        ```
     """
 
     tableau: ClassVar[StochasticButcherTableau] = _tab

--- a/diffrax/_solver/slowrk.py
+++ b/diffrax/_solver/slowrk.py
@@ -3,19 +3,14 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    GeneralCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, GeneralCoeffs, StochasticButcherTableau
 
 
 # TODO: maybe this solver should use a custom implementation, not going via
 # `AbstractSRK`? Its tableaus have huge amounts of sparsity due to its odd structure.
 
 
-cfs_w = GeneralCoeffs(
+_coeffs_w = GeneralCoeffs(
     a=(
         np.array([0.0]),
         np.array([0.0, 0.5]),
@@ -24,11 +19,11 @@ cfs_w = GeneralCoeffs(
         np.array([0.0, 0.0, 0.0, 0.75, 0.0]),
         np.array([0.0, 0.0, 0.5, 0.0, 0.0, 0.0]),
     ),
-    b=np.array([0.0, 1 / 6, 1 / 3, 1 / 3, 1 / 6, 0.0, 0.0]),
+    b_sol=np.array([0.0, 1 / 6, 1 / 3, 1 / 3, 1 / 6, 0.0, 0.0]),
     b_error=None,
 )
 
-cfs_hh = GeneralCoeffs(
+_coeffs_hh = GeneralCoeffs(
     a=(
         np.array([0.0]),
         np.array([0.0, 0.0]),
@@ -37,19 +32,11 @@ cfs_hh = GeneralCoeffs(
         np.array([0.0, 0.0, 0.0, 1.5, 0.0]),
         np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     ),
-    b=np.array([0.0, 0.0, 0.0, 2.0, 0.0, 0.0, -2.0]),
+    b_sol=np.array([0.0, 0.0, 0.0, 2.0, 0.0, 0.0, -2.0]),
     b_error=None,
-)
-
-cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
 )
 
 _tab = StochasticButcherTableau(
-    c=np.array([0.5, 0.5, 0.5, 0.5, 0.75, 1.0]),
-    b_sol=np.array([1 / 3, 0.0, 0.0, 0.0, 0.0, 2 / 3, 0.0]),
-    b_error=None,
     a=[
         np.array([0.5]),
         np.array([0.5, 0.0]),
@@ -58,7 +45,12 @@ _tab = StochasticButcherTableau(
         np.array([0.75, 0.0, 0.0, 0.0, 0.0]),
         np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]),
     ],
-    cfs_bm=cfs_bm,
+    b_sol=np.array([1 / 3, 0.0, 0.0, 0.0, 0.0, 2 / 3, 0.0]),
+    b_error=None,
+    c=np.array([0.5, 0.5, 0.5, 0.5, 0.75, 1.0]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
     ignore_stage_f=np.array([False, True, True, True, True, False, True]),
     ignore_stage_g=np.array([True, False, False, False, False, True, False]),
 )

--- a/diffrax/_solver/spark.py
+++ b/diffrax/_solver/spark.py
@@ -3,40 +3,34 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    GeneralCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, GeneralCoeffs, StochasticButcherTableau
 
 
 _x1 = (3 - np.sqrt(3)) / 6
 _x2 = np.sqrt(3) / 3
 
-cfs_w = GeneralCoeffs(
+_coeffs_w = GeneralCoeffs(
     a=(np.array([0.5]), np.array([0.0, 1.0])),
-    b=np.array([_x1, _x2, _x1]),
+    b_sol=np.array([_x1, _x2, _x1]),
     b_error=np.array([_x1 - 0.5, _x2, _x1 - 0.5]),
 )
 
-cfs_hh = GeneralCoeffs(
+_coeffs_hh = GeneralCoeffs(
     a=(np.array([np.sqrt(3.0)]), np.array([0.0, 0.0])),
-    b=np.array([1.0, 0.0, -1.0]),
+    b_sol=np.array([1.0, 0.0, -1.0]),
     b_error=np.array([1.0, 0.0, -1.0]),
 )
 
-cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
-)
-
 _tab = StochasticButcherTableau(
-    c=np.array([0.5, 1.0]),
-    b_sol=np.array([_x1, _x2, _x1]),
     a=[np.array([0.5]), np.array([0.0, 1.0])],
+    b_sol=np.array([_x1, _x2, _x1]),
     b_error=np.array([_x1 - 0.5, _x2, _x1 - 0.5]),
-    cfs_bm=cfs_bm,
+    c=np.array([0.5, 1.0]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
+    ignore_stage_f=None,
+    ignore_stage_g=None,
 )
 
 

--- a/diffrax/_solver/spark.py
+++ b/diffrax/_solver/spark.py
@@ -41,16 +41,22 @@ _tab = StochasticButcherTableau(
 
 
 class SPaRK(AbstractSRK, AbstractStratonovichSolver):
-    r"""The Splitting Path Runge-Kutta method by James Foster.
-    It uses three evaluations of the vector field per step and
-    has the following strong orders of convergence:
+    r"""The Splitting Path Runge-Kutta method.
+
+    It uses three evaluations of the drift and diffusion per step, and has the following
+    strong orders of convergence:
+
     - 1.5 for SDEs with additive noise
-    - 1.0 for SDEs with commutative noise
-    - 0.5 for general SDEs.
-    Despite being slower than methods like ShARK or SRA1, it works for a wider class
-    of SDEs. It is based on Definition 1.6 from
+    - 1.0 for Stratonovich SDEs with commutative noise
+    - 0.5 for Stratonovich SDEs with general noise.
+
+    Despite being slower than methods like [`diffrax.ShARK`][] or [`diffrax.SRA1`][]
+    (which each only make two drift and diffusion evaluations per step), this solver
+    is designed to still produce good results regardless of the noise type of the SDE.
 
     ??? cite "Reference"
+
+        This solver is based on Definition 1.6 from
 
         ```bibtex
         @misc{foster2023convergence,

--- a/diffrax/_solver/spark.py
+++ b/diffrax/_solver/spark.py
@@ -5,7 +5,7 @@ import numpy as np
 from .base import AbstractStratonovichSolver
 from .srk import (
     AbstractSRK,
-    GeneralCoeffsWithError,
+    GeneralCoeffs,
     SpaceTimeLevyAreaTableau,
     StochasticButcherTableau,
 )
@@ -14,19 +14,19 @@ from .srk import (
 _x1 = (3 - np.sqrt(3)) / 6
 _x2 = np.sqrt(3) / 3
 
-cfs_w = GeneralCoeffsWithError(
+cfs_w = GeneralCoeffs(
     a=(np.array([0.5]), np.array([0.0, 1.0])),
     b=np.array([_x1, _x2, _x1]),
     b_error=np.array([_x1 - 0.5, _x2, _x1 - 0.5]),
 )
 
-cfs_hh = GeneralCoeffsWithError(
+cfs_hh = GeneralCoeffs(
     a=(np.array([np.sqrt(3.0)]), np.array([0.0, 0.0])),
     b=np.array([1.0, 0.0, -1.0]),
     b_error=np.array([1.0, 0.0, -1.0]),
 )
 
-cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffsWithError](
+cfs_bm = SpaceTimeLevyAreaTableau[GeneralCoeffs](
     coeffs_w=cfs_w,
     coeffs_hh=cfs_hh,
 )

--- a/diffrax/_solver/sra1.py
+++ b/diffrax/_solver/sra1.py
@@ -36,17 +36,20 @@ _tab = StochasticButcherTableau(
 
 
 class SRA1(AbstractSRK, AbstractStratonovichSolver):
-    r"""Based on the SRA1 method by Andreas Rößler.
-    Works only for SDEs with additive noise, applied to which, it has
-    strong order 1.5. Uses two evaluations of the vector field per step.
+    r"""The SRA1 method for additive-noise SDEs.
+
+    Makes two evaluations of the drift and diffusion per step and has a strong order
+    1.5.
+
+    See also [`diffrax.ShARK`][], which is very similar.
 
     ??? cite "Reference"
 
         ```bibtex
         @article{rossler2010runge
-            author = {R\"{o}\ss{}ler, Andreas},
-            title = {Runge–Kutta Methods for the Strong Approximation of
-                Solutions of Stochastic Differential Equations},
+            author = {Andreas R\"{o}\ss{}ler},
+            title = {Runge–Kutta Methods for the Strong Approximation of Solutions of
+                     Stochastic Differential Equations},
             journal = {SIAM Journal on Numerical Analysis},
             volume = {48},
             number = {3},

--- a/diffrax/_solver/sra1.py
+++ b/diffrax/_solver/sra1.py
@@ -3,35 +3,29 @@ from typing import ClassVar
 import numpy as np
 
 from .base import AbstractStratonovichSolver
-from .srk import (
-    AbstractSRK,
-    AdditiveCoeffs,
-    SpaceTimeLevyAreaTableau,
-    StochasticButcherTableau,
-)
+from .srk import AbstractSRK, AdditiveCoeffs, StochasticButcherTableau
 
 
-cfs_w = AdditiveCoeffs(
+_coeffs_w = AdditiveCoeffs(
     a=np.array([0.0, 3 / 4]),
-    b=np.array(1.0),
+    b_sol=np.array(1.0),
 )
 
-cfs_hh = AdditiveCoeffs(
+_coeffs_hh = AdditiveCoeffs(
     a=np.array([0.0, 1.5]),
-    b=np.array(0.0),
-)
-
-cfs_bm = SpaceTimeLevyAreaTableau[AdditiveCoeffs](
-    coeffs_w=cfs_w,
-    coeffs_hh=cfs_hh,
+    b_sol=np.array(0.0),
 )
 
 _tab = StochasticButcherTableau(
-    c=np.array([3 / 4]),
+    a=[np.array([3 / 4])],
     b_sol=np.array([1 / 3, 2 / 3]),
     b_error=np.array([-2 / 3, 2 / 3]),
-    a=[np.array([3 / 4])],
-    cfs_bm=cfs_bm,
+    c=np.array([3 / 4]),
+    coeffs_w=_coeffs_w,
+    coeffs_hh=_coeffs_hh,
+    coeffs_kk=None,
+    ignore_stage_f=None,
+    ignore_stage_g=None,
 )
 
 

--- a/diffrax/_solver/srk.py
+++ b/diffrax/_solver/srk.py
@@ -346,7 +346,7 @@ class AbstractSRK(AbstractSolver[_SolverState]):
     """
 
     interpolation_cls = LocalLinearInterpolation
-    term_compatible_contr_kwargs = dict(use_levy=True)
+    term_compatible_contr_kwargs = (dict(), dict(use_levy=True))
     tableau: AbstractClassVar[StochasticButcherTableau]
 
     # Indicates the type of Levy area used by the solver.

--- a/docs/api/solvers/sde_solvers.md
+++ b/docs/api/solvers/sde_solvers.md
@@ -20,7 +20,9 @@ See also [How to choose a solver](../../usage/how-to-choose-a-solver.md#stochast
 
 ---
 
-### Explicit Runge--Kutta (ERK) methods
+## Explicit Runge--Kutta (ERK) methods
+
+These solvers can be used to solve SDEs just as well as they can be used to solve ODEs.
 
 ::: diffrax.Euler
     selection:
@@ -44,45 +46,7 @@ See also [How to choose a solver](../../usage/how-to-choose-a-solver.md#stochast
 
 ---
 
-### Stochastic Runge--Kutta (SRK)
-
-::: diffrax.ShARK
-    selection:
-        members: false
-
-::: diffrax.GeneralShARK
-    selection:
-        members: false
-
-::: diffrax.SRA1
-    selection:
-        members: false
-
-::: diffrax.SEA
-    selection:
-        members: false
-
-::: diffrax.SPaRK
-    selection:
-        members: false
-
-::: diffrax.SlowRK
-    selection:
-        members: false
-
----
-
-### Reversible methods
-
-These are reversible in the same way as when applied to ODEs. [See here.](./ode_solvers.md#reversible-methods)
-
-::: diffrax.ReversibleHeun
-    selection:
-        members: false
-
----
-
-### SDE-only solvers
+## SDE-only solvers
 
 !!! info "Term structure"
 
@@ -98,6 +62,44 @@ These are reversible in the same way as when applied to ODEs. [See here.](./ode_
         members: false
 
 ::: diffrax.StratonovichMilstein
+    selection:
+        members: false
+
+### Stochastic Runge--Kutta (SRK)
+
+These are a particularly important class of SDE-only solvers.
+
+::: diffrax.SEA
+    selection:
+        members: false
+
+::: diffrax.SRA1
+    selection:
+        members: false
+
+::: diffrax.ShARK
+    selection:
+        members: false
+
+::: diffrax.GeneralShARK
+    selection:
+        members: false
+
+::: diffrax.SlowRK
+    selection:
+        members: false
+
+::: diffrax.SPaRK
+    selection:
+        members: false
+
+---
+
+### Reversible methods
+
+These are reversible in the same way as when applied to ODEs. [See here.](./ode_solvers.md#reversible-methods)
+
+::: diffrax.ReversibleHeun
     selection:
         members: false
 

--- a/docs/usage/how-to-choose-a-solver.md
+++ b/docs/usage/how-to-choose-a-solver.md
@@ -73,9 +73,9 @@ For Itô SDEs:
 
 For Stratonovich SDEs:
 
-- If cheap low-accuracy solves are desired then [`diffrax.EulerHeun`][] is a good choice.
-- Otherwise, and if the noise is commutative, then [`diffrax.StratonovichMilstein`][] is a typical choice.
-- Otherwise, and if the noise is noncommutative, then [`diffrax.Heun`][] is a typical choice.
+- If cheap low-accuracy solves are desired then [`diffrax.EulerHeun`][] is a typical choice.
+- Otherwise, and if the noise is commutative, then [`diffrax.StratonovichMilstein`][] or [`diffrax.SlowRK`][] are good choices.
+- Otherwise, and if the noise is noncommutative, then [`diffrax.Heun`][] or [`diffrax.GeneralShARK`][] are good choices.
 
 ### Additive noise
 
@@ -85,10 +85,10 @@ $\mathrm{d}y(t) = μ(t, y(t))\mathrm{d}t + σ(t, y(t))\mathrm{d}w(t)$
 
 Then the diffusion matrix $σ$ is said to be additive if $σ(t, y) = σ(t)$. That is to say if the diffusion is independent of $y$.
 
-In this case then the Itô solution and the Stratonovich solution coincide, and mathematically speaking the choice of Itô vs Stratonovich is unimportant.
+In this case then the Itô solution and the Stratonovich solution coincide, and mathematically speaking the choice of Itô vs Stratonovich is unimportant. Special solvers for additive-noise SDEs tend to do particularly well as compared to the general Itô or Stratonovich solvers discussed above.
 
-- The cheapest (but least accurate) solver is [`diffrax.Euler`][].
-- Otherwise [`diffrax.Heun`][] is a good choice. It gets first-order strong convergence and second-order weak convergence.
+- The cheapest (but least accurate) solver is [`diffrax.SEA`][].
+- Otherwise [`diffrax.ShARK`][] or [`diffrax.SRA1`][] are good choices.
 
 ---
 


### PR DESCRIPTION
Okay, as I start to think about merging https://github.com/patrick-kidger/diffrax/pull/344, I've been going through things carefully and fixing things up.

Here's a pull request against your branch, which I think does a lot of what needs doing. Can you give it a review and make sure that everything here seems reasonable?

It contains multiple commits -- you may find it easiest to tackle each of these individually, as I've tried to group changes logically.

1. Moves `resulting_levy_area` from the main library into the tests, which is the only usage of it.
2. I realised that it's not sufficient to have `term_compatible_contr_kwargs` have a single thing on the solver -- we need something with essentially the same tree structure as `term_structure`, so that we can map the kwargs to each term. So I reworked this.
3. This is just fixing up lots of documentation. Do please make sure that everything I've written is accurate!
4. This is miscellaneous fix-ups, mostly to `srk.py`.
5. This is adjusting `srk.py` to remove the classes like `_AbstractSTLACoeffs`, which I don't think are really necessary: it seems much simpler to just place the coefficient-groups on the `StochasticButcherTableau` object directly. It also removes the default arguments -- for (mostly-)internal APIs I think these tend to be an antipattern that should be avoided, since they're such a common source of surprising behaviour!